### PR TITLE
feat: add podLabels field to PeriodicRestartSpec

### DIFF
--- a/api/v1/mastodonserver_types.go
+++ b/api/v1/mastodonserver_types.go
@@ -12,6 +12,7 @@ type PeriodicRestartSpec struct {
 	Enabled            bool                       `json:"enabled,omitempty"`
 	Schedule           string                     `json:"schedule,omitempty"`
 	TimeZone           *string                    `json:"timeZone,omitempty"`
+	PodLabels          map[string]string          `json:"podLabels,omitempty"`
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	SecurityContext    *corev1.SecurityContext    `json:"securityContext,omitempty"`
 }

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -435,6 +435,13 @@ func (in *PeriodicRestartSpec) DeepCopyInto(out *PeriodicRestartSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.PodLabels != nil {
+		in, out := &in.PodLabels, &out.PodLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.PodSecurityContext != nil {
 		in, out := &in.PodSecurityContext, &out.PodSecurityContext
 		*out = new(corev1.PodSecurityContext)

--- a/charts/magout-cluster-wide/templates/magout.anqou.net_mastodonservers.yaml
+++ b/charts/magout-cluster-wide/templates/magout.anqou.net_mastodonservers.yaml
@@ -1181,6 +1181,10 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      podLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       podSecurityContext:
                         description: |-
                           PodSecurityContext holds pod-level security attributes and common container settings.
@@ -5440,6 +5444,10 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      podLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       podSecurityContext:
                         description: |-
                           PodSecurityContext holds pod-level security attributes and common container settings.
@@ -9699,6 +9707,10 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      podLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       podSecurityContext:
                         description: |-
                           PodSecurityContext holds pod-level security attributes and common container settings.

--- a/charts/magout/values.yaml
+++ b/charts/magout/values.yaml
@@ -22,6 +22,7 @@ mastodonServer:
       enabled: false
       schedule: "0 0 * * *"
       # timeZone: UTC
+      podLabels: {}
       podSecurityContext:
         runAsNonRoot: true
         runAsUser: 991
@@ -57,6 +58,7 @@ mastodonServer:
       enabled: false
       schedule: "0 0 * * *"
       # timeZone: UTC
+      podLabels: {}
       podSecurityContext:
         runAsNonRoot: true
         runAsUser: 991
@@ -92,6 +94,7 @@ mastodonServer:
       enabled: false
       schedule: "0 0 * * *"
       # timeZone: UTC
+      podLabels: {}
       podSecurityContext:
         runAsNonRoot: true
         runAsUser: 991

--- a/internal/controller/mastodonserver_controller.go
+++ b/internal/controller/mastodonserver_controller.go
@@ -487,6 +487,13 @@ func (r *MastodonServerReconciler) createOrUpdatePeriodicRestartCronJob(
 			cronJob.Spec.Suspend = &fals
 			templ.SecurityContext = spec.PodSecurityContext
 			templ.Containers[0].SecurityContext = spec.SecurityContext
+
+			if spec.PodLabels != nil {
+				if cronJob.Spec.JobTemplate.Spec.Template.Labels == nil {
+					cronJob.Spec.JobTemplate.Spec.Template.Labels = map[string]string{}
+				}
+				maps.Copy(cronJob.Spec.JobTemplate.Spec.Template.Labels, spec.PodLabels)
+			}
 		}
 
 		return ctrl.SetControllerReference(server, &cronJob, r.Scheme)


### PR DESCRIPTION
Allow users to specify custom labels on pods created by the periodic restart CronJob for each Mastodon component (sidekiq, web, streaming).