### PR TITLE
feat(charts): add pod scheduling/annotation fields

### DIFF
--- a/charts/magout/templates/mastodonserver.yaml
+++ b/charts/magout/templates/mastodonserver.yaml
@@ -51,6 +51,26 @@ spec:
     volumes:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.mastodonServer.sidekiq.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.sidekiq.affinity }}
+    affinity:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.sidekiq.tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.sidekiq.topologySpreadConstraints }}
+    topologySpreadConstraints:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.sidekiq.podAnnotations }}
+    podAnnotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   web:
     image: {{ .Values.mastodonVersion.image }}
     {{- with .Values.mastodonServer.web.replicas }}
@@ -98,6 +118,26 @@ spec:
     volumes:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.mastodonServer.web.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.web.affinity }}
+    affinity:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.web.tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.web.topologySpreadConstraints }}
+    topologySpreadConstraints:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.web.podAnnotations }}
+    podAnnotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   streaming:
     image: {{ .Values.mastodonVersion.streamingImage }}
     {{- with .Values.mastodonServer.streaming.replicas }}
@@ -143,5 +183,25 @@ spec:
     {{- end }}
     {{- with .Values.mastodonServer.streaming.volumes }}
     volumes:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.streaming.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.streaming.affinity }}
+    affinity:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.streaming.tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.streaming.topologySpreadConstraints }}
+    topologySpreadConstraints:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mastodonServer.streaming.podAnnotations }}
+    podAnnotations:
       {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/magout/values.yaml
+++ b/charts/magout/values.yaml
@@ -46,6 +46,11 @@ mastodonServer:
           - ALL
     volumeMounts: []
     volumes: []
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    topologySpreadConstraints: []
+    podAnnotations: {}
   web:
     replicas: 1
     labels: {}
@@ -81,6 +86,11 @@ mastodonServer:
           - ALL
     volumeMounts: []
     volumes: []
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    topologySpreadConstraints: []
+    podAnnotations: {}
   streaming:
     replicas: 1
     labels: {}
@@ -116,6 +126,11 @@ mastodonServer:
           - ALL
     volumeMounts: []
     volumes: []
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    topologySpreadConstraints: []
+    podAnnotations: {}
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Expose nodeSelector, affinity, tolerations, topologySpreadConstraints and podAnnotations for the sidekiq, web and streaming components. These fields are already supported by the MastodonServer CRD and controller but were not configurable through the Helm chart.